### PR TITLE
修复 README 中受损的点赞历史图表

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,5 +15,5 @@ https://v.kuaishou.com/nGmUFX 自动化完成淘宝任务教程 该作品在快�
 
 ## 点赞历史
 
-[![Star History Chart](https://api.star-history.com/svg?repos=czl0325/coin11-tb&type=Date)](https://star-history.com/#czl0325/coin11-tbt&Date)
+[![Star History Chart](https://star-history.dera.page/svg?repos=czl0325/coin11-tb&type=Date)](https://star-history.dera.page/#czl0325/coin11-tbt&Date)
 <br><br>


### PR DESCRIPTION
目前 README 中的点赞历史图表已经无法正常显示了，原因是 GitHub 星标数据接口的限制导致旧图表失效。本次更新将图表地址迁移到新的数据源，修复后可正常展示项目点赞历史，建议尽快合入。